### PR TITLE
Query for 100 streams instead of 25

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ function ensureDir(dirPath) {
  * @param {requestCallback} callback - The callback that handles the response.
  */
 function listStreams(twitch, callback) {
-  let parameters = {"game": "PLAYERUNKNOWN\'S BATTLEGROUNDS", "language": "en"};
+  let parameters = {"game": "PLAYERUNKNOWN\'S BATTLEGROUNDS", "language": "en", "length": 100};
 
   twitch.streams.live(parameters, function(err, body) {
     if (err) console.log(err);


### PR DESCRIPTION
While paging through the whole list would eventually be better, just
grabbing 100 to start with is four times better than what we are doing
today.