### PR TITLE
Update travisCI badge and eslint docs for promises

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,4 @@
+public/js/bootstrap.min.js
 public/js/jquery.js
+public/js/jquery-3.2.1.slim.min.js
+public/js/popper.min.js

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pubgredzone
 
 [![npm version](https://badge.fury.io/js/pubgredzone.svg)](https://badge.fury.io/js/pubgredzone)
-[![Build Status](https://travis-ci.org/eggshell/pubgredzone.svg?branch=master)](https://travis-ci.org/eggshell/pubgredzone)
+[![Build Status](https://api.travis-ci.org/IBM/pubgredzone.svg?branch=master)](https://travis-ci.org/IBM/pubgredzone)
 [![Docker Automated build](https://img.shields.io/docker/automated/jrottenberg/ffmpeg.svg)](https://hub.docker.com/r/eggshell/pubgredzone/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/app.js
+++ b/app.js
@@ -53,7 +53,8 @@ function ensureDir(dirPath) {
  * @param {requestCallback} callback - The callback that handles the response.
  */
 function listStreams(twitch, callback) {
-  let parameters = {"game": "PLAYERUNKNOWN\'S BATTLEGROUNDS", "language": "en", "length": 100};
+  let parameters = {"game": "PLAYERUNKNOWN\'S BATTLEGROUNDS",
+    "language": "en", "length": 100};
 
   twitch.streams.live(parameters, function(err, body) {
     if (err) console.log(err);
@@ -72,13 +73,15 @@ function listStreams(twitch, callback) {
  * @param {string} streamName - name of stream to record.
  * @param {string} clipsDir - Relative path to directory containing short
  * recorded clips of each stream in streamsList.
+ * @return {promise} - A promise that resolves if a stream is recorded.
  */
 function recordStream(options) {
   return new Promise((resolve, reject) => {
     console.log("recording clip of stream: " + options.streamName);
-    const child = spawn("livestreamer", ["--yes-run-as-root", "-Q", "-f", "--twitch-oauth-token",
-      process.env.token, "twitch.tv/" + options.streamName,
-      "720p", "-o", options.clipsDir + options.streamName + ".mp4"]);
+    const child = spawn("livestreamer", ["--yes-run-as-root", "-Q", "-f",
+      "--twitch-oauth-token", process.env.token,
+      "twitch.tv/" + options.streamName, "720p", "-o",
+      options.clipsDir + options.streamName + ".mp4"]);
     setTimeout(function() {
       child.kill("SIGINT");
       console.log("recorded stream: " + options.streamName);
@@ -95,7 +98,7 @@ function recordStream(options) {
  * recorded clips of each stream in streamsList.
  * @param {string} thumbnailsDir - Relative path to directory containing
  * screenshots of each clip recorded in recordStreams.
- * @param {requestCallback} callback - The callback that handles the response.
+ * @return {promise} - a promise that resolves if a screenshot is taken.
  */
 function takeScreenshot(options) {
   return new Promise((resolve, reject) => {
@@ -123,6 +126,7 @@ function takeScreenshot(options) {
  * screenshots of each clip recorded in recordStream.
  * @param {string} cropsDir - Relative path to directory containing cropped
  * versions of all screenshots taken in takeScreenshot.
+ * @return {promise} - a promise which resolves if a screenshot is cropped.
  */
 function cropScreenshot(options) {
   return new Promise((resolve, reject) => {
@@ -146,7 +150,8 @@ function cropScreenshot(options) {
  * OCR the data (via web request)
  * Uses the pubgredzone-ocr microservice
  * @param {object} options - object of other params
- *
+ * @return {promise} - a promise that is resolved if the a screenshot is ocr'd
+ * successfully.
  */
 function ocrCroppedShot(options) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
* TravisCI badge was still pointed at the old repo. This will update it.
* Updates eslint docs for the inclusion of promises so TravisCI will
  resume passing.
*  Add bootstrap, jquery, and popper js files to .eslintignore.

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>