### PR TITLE
Add additional logging to /process_pubg

### DIFF
--- a/ocr.js
+++ b/ocr.js
@@ -54,7 +54,9 @@ app.post("/process_pubg", upload.single("image"), function(req, res, next) {
   tesseract.process(output, options, function(err, text) {
     if (err) {
       res.json({"number": 100});
-      console.log("File crashed tesseract-ocr: " + output);
+      console.log(
+        "Tesseract failed to process file: %s with error: %s", output, err
+      );
     } else {
       let number = parseFloat(text.trim());
       // Return any garbage as 100 (dead, out of game, etc)


### PR DESCRIPTION
Currently this function only logs the file which tesseract
failed to parse. This change logs the error message from
tesseract as well to aid in debugging.