### PR TITLE
Alpine images redux

### DIFF
--- a/deploy/images/app.Dockerfile
+++ b/deploy/images/app.Dockerfile
@@ -1,15 +1,16 @@
-FROM ubuntu:16.04
-
-RUN apt-get update; apt-get install -y ffmpeg imagemagick curl git
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get update && apt-get install nodejs -y
-RUN apt-get install -y python-dev python-pip; pip install livestreamer
+FROM node:8-alpine
 
 COPY . /
-RUN npm install
+RUN echo http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+    apk add --no-cache livestreamer ffmpeg imagemagick  py2-singledispatch && \
+    npm install
+
+ARG OCR_HOST
+ENV OCR_HOST=$OCR_HOST
 
 ARG token
 ENV token=$token
 
 EXPOSE 3000
+
 CMD ["node", "app.js"]

--- a/deploy/images/ocr.Dockerfile
+++ b/deploy/images/ocr.Dockerfile
@@ -1,14 +1,19 @@
-FROM ubuntu:16.04
-
-RUN apt-get update; apt-get install -y tesseract-ocr curl git
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get update && apt-get install nodejs -y
+FROM node:8-alpine
 
 COPY . /
-RUN npm install
+# Once tesseract-ocr-3.05 is availble all of this wget stuff
+# can go away. 3.05 includes the english training data while
+# 3.04 doesn't. Currently 3.05 can't be installed from edge because
+# of broken dependencies.
+RUN apk --update --no-cache --virtual wget-deps add ca-certificates openssl && \
+    apk --no-cache add tesseract-ocr git && \
+    wget -q -P /usr/share/tessdata/ https://github.com/tesseract-ocr/tessdata/raw/master/eng.traineddata && \
+    apk del wget-deps && \
+    npm install
 
 ARG token
 ENV token=$token
 
 EXPOSE 3001
+
 CMD ["node", "ocr.js"]


### PR DESCRIPTION
The previous Alpine images failed due to missing English training
data. The Alpine package for tesseract 3.04 does not install that
training data so it must be downloaded manually.