### PR TITLE
Update testing process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,22 @@
 ---
-dist: trusty
-language: node_js
-node_js:
-  - "node"
-
 notifications:
   email: false
 
-matrix:
-  fast_finish: true
+jobs:
+  include:
+    - stage: lint
+      script: eslint .
+      language: node_js
+      node_js:
+        - "node"
+      install:
+        - npm install -g eslint eslint-config-google
 
-env:
-  - TEST_RUN="eslint ."
-  - TEST_RUN="./tests/test_ocr_service.sh"
-
-before_install:
-  - npm install -g eslint eslint-config-google
-  - sudo apt-get install tesseract-ocr
-
-install:
-  - npm install .
-
-script: "$TEST_RUN"
+    - stage: test app
+      language: bash
+      services:
+        - docker
+      script:
+        - ./tests/build-containers
+        - ./tests/deploy-containers
+        - ./tests/test_ocr_service.sh

--- a/tests/build-containers
+++ b/tests/build-containers
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -f deploy/images/app.Dockerfile -t "pubgredzone:app" . && \
+  docker build -f deploy/images/ocr.Dockerfile -t "pubgredzone:ocr" .

--- a/tests/deploy-containers
+++ b/tests/deploy-containers
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker run -d -p 3001:3001 --name pubgredzone-ocr pubgredzone:ocr
+docker run -d -e token=$token -e OCR_HOST="127.0.0.1:3001" -p 3000:3000 --name pubgredzone-app pubgredzone:app
+
+docker ps | grep -q pubgredzone:app && docker ps | grep -q pubgredzone:ocr


### PR DESCRIPTION
* The CI run has been split into two stages: linting and testing
  the OCR application. If linting fails the CI run will abort.

* The container build process is now tested.

* The test_ocr_service script has been changed to use the newly
  built container instead of starting the OCR process itself.