### PR TITLE
Handle unhandled promise rejection

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,5 +26,6 @@ module.exports = {
             "always"
         ],
         "guard-for-in": 0,
+        "prefer-promise-reject-errors": 2
     }
 };

--- a/app.js
+++ b/app.js
@@ -140,7 +140,7 @@ function cropScreenshot(options) {
         });
       console.log("cropped screenshot of: " + options.streamName);
     } else {
-      reject(streamName + ": input file not found");
+      reject(new Error(options.streamName + ": input file not found"));
     }
   });
 }
@@ -209,6 +209,8 @@ function updateStreamsList(cropsDir) {
         .then(ocrCroppedShot)
         .then(function(streamobj) {
           array.push(streamobj);
+        }).catch((error) => {
+          console.log(error.message);
         });
     }
 


### PR DESCRIPTION
An instance of the built-in Error object is now passed to the
rejection and a corresponding eslint rule to enforce that has
been enabled. A non-existent variable in the error message has
also been fixed.