### PR TITLE
Add condition to handle player alive ties

### DIFF
--- a/public/js/pubgredzone.js
+++ b/public/js/pubgredzone.js
@@ -15,7 +15,7 @@ $(document).ready(function() {
       console.log((currentStream != top_result["stream_url"] ) )
       $("#streamer_name").text(top_result["stream_name"] + " - " + top_result["alive"]);
       $("#next_closest").text(second_result["stream_name"] + " - " + second_result["alive"]);
-      if (currentStream != top_result["stream_url"] ) {
+      if (currentStream != top_result["stream_url"] && currentStream["alive"] != top_result["alive"]) {
         $("#twitch_iframe").prop("src", top_result["stream_url"]);
       }
     });


### PR DESCRIPTION
If two players have the exact same number of people alive, we will
infer that they are on the same team and not switch streams.

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>